### PR TITLE
Add optional rel me link to blog template

### DIFF
--- a/app/elements/site-footer.mjs
+++ b/app/elements/site-footer.mjs
@@ -1,6 +1,10 @@
 export default function SiteFooter ({ html }) {
+  const me = null // Ex. 'https://social.example.com/@username'
   return html`
     <footer class='pt4 pt6-lg pb4 pb6-lg'>
+      ${me && `<p class='text-center pb-4'>
+        <a rel='me' href='${me}' class='font-body text-1 uppercase tracking3 underline'>Mastodon</a>
+      </p>`}
       <p class='text-center'>
         <a href='/rss' class='font-body text-1 uppercase tracking3 underline'>RSS</a>
       </p>


### PR DESCRIPTION
This adds a link to your Mastodon account in the footer of the blog template. Let me know what you think of the implementation and whether or not it should be somewhere else on the page.